### PR TITLE
Add ability to set ratio, seeding time per tracker:

### DIFF
--- a/QbtManager/Program.cs
+++ b/QbtManager/Program.cs
@@ -146,6 +146,7 @@ namespace QbtManager
             var toKeep = new List<Torrent>();
             var toDelete = new List<Torrent>();
             var limits = new Dictionary<Torrent, int>();
+            var maxLimits = new Dictionary<Torrent, (float,int)>(); // max ratio, seeding time. API requires they both get set at once
 
             foreach (var task in tasks)
             {
@@ -171,6 +172,28 @@ namespace QbtManager
                         // Store the tracker limits.
                         limits[task] = tracker.up_limit.Value;
                     }
+
+                    if (tracker != null && tracker.max_ratio.HasValue && task.max_ratio != tracker.max_ratio)
+                    {
+                        // Store the tracker limits.
+                        maxLimits[task] = (tracker.max_ratio.Value, task.max_seeding_time);
+                        // API call can't set just one have to set both
+                    }
+
+                    if (tracker != null && tracker.max_seeding_time.HasValue && task.max_seeding_time != tracker.max_seeding_time)
+                    {
+                        // Store the tracker limits.
+                        // API call can't set just one have to set both
+                        if (maxLimits.ContainsKey(task))
+                        {
+                            maxLimits[task] = (maxLimits[task].Item1, tracker.max_seeding_time.Value);
+                        }
+                        else
+                        {
+                            maxLimits[task] = (task.max_ratio, tracker.max_seeding_time.Value);
+                        }
+
+                    }
                 }
                 else
                 {
@@ -190,6 +213,22 @@ namespace QbtManager
 
                     if (!service.SetUploadLimit(hashes, limit))
                         Utils.Log($"Failed to set upload limits.");
+                }
+            }
+
+            if (maxLimits.Any())
+            {
+                var ratioGroups = maxLimits.GroupBy(x => x.Value, y => y.Key);
+
+                foreach (var x in ratioGroups)
+                {
+                    float ratio_limit = x.Key.Item1;
+                    int time_limit = x.Key.Item2;
+
+                    var hashes = x.Select(t => t.hash).ToArray();
+
+                    if (!service.SetMaxLimits(hashes, ratio_limit, time_limit))
+                        Utils.Log($"Failed to set max ratio and time limit.");
                 }
             }
 

--- a/QbtManager/Settings.cs
+++ b/QbtManager/Settings.cs
@@ -43,6 +43,17 @@ namespace QbtManager
         public int maxDaysToKeep { get; set; }
         [DataMember]
         public int diskFileAgeBeforeDeleteMins = 15;
+        /// <summary>
+        /// -1 = no limit, -2 = global limit, other value = custom ratio value for this torrent
+        /// </summary>
+        [DataMember]
+        public float? max_ratio { get; set; }
+
+        /// <summary>
+        /// -1 = no limit, -2 = global limit, other value = minutes to seed for this torrent
+        /// </summary>
+        [DataMember]
+        public int? max_seeding_time { get; set; }
         [DataMember]
         public int? up_limit { get; set; }
         [DataMember]

--- a/QbtManager/qbtService.cs
+++ b/QbtManager/qbtService.cs
@@ -31,6 +31,8 @@ namespace QbtManager
             public string magnet_uri { get; set; }
             public string state { get; set; }
             public int up_limit { get; set; }
+            public float max_ratio { get; set; }
+            public int max_seeding_time { get; set; }
             public DateTime added_on { get; set; }
             public DateTime completed_on { get; set; }
             public List<Tracker> trackers { get; set; }
@@ -181,6 +183,24 @@ namespace QbtManager
             parms["limit"] = limitBytesPerSec.ToString();
 
             return ExecuteCommand("/torrents/setUploadLimit", parms);
+        }
+
+        /// <summary>
+        /// Sets the maximum ratio and seeding time for a list of hashes
+        /// </summary>
+        /// <param name="taskIds"></param>
+        /// <param name="maxRatio">Maximum Ratio, -2 = none, -1 = use global, other value = custom ratio per torrent</param>
+        /// <param name="maxSeedingTime">Maximum Seeding Time, -2 = none, -1 = use global, other value = minutes to seed this torrent</param>
+        /// <returns></returns>
+        public bool SetMaxLimits(string[] taskIds, float maxRatio, int maxSeedingTime)
+        {
+            var parms = new Dictionary<string, string>();
+
+            parms["hashes"] = string.Join("|", taskIds);
+            parms["ratioLimit"] = maxRatio.ToString();
+            parms["seedingTimeLimit"] = maxSeedingTime.ToString();
+            Utils.Log("Setting Limits to ratio " + parms["ratioLimit"] + " seeding time " + parms["seedingTimeLimit"] + " for " + taskIds.Length.ToString() + " tasks ");
+            return ExecuteCommand("/torrents/setShareLimits", parms);
         }
 
         /// <summary>


### PR DESCRIPTION
      "max_ratio": -1,
      "max_seeding_time": -1,

Where -1 means do not use for this tracker, -2 means use global value, and a number means ratio or minutes to seed for this tracker
