### PR TITLE
Fix missing parameter in setShareLimits

### DIFF
--- a/QbtManager/Settings.cs
+++ b/QbtManager/Settings.cs
@@ -54,6 +54,12 @@ namespace QbtManager
         /// </summary>
         [DataMember]
         public int? max_seeding_time { get; set; }
+        
+        /// <summary>
+        /// -1 = no limit, -2 = global limit, other value = minutes to seed for this torrent while inactive
+        /// </summary>
+        [DataMember]
+        public int? max_inactive_seeding_time { get; set; }
         [DataMember]
         public int? up_limit { get; set; }
         [DataMember]

--- a/QbtManager/qbtService.cs
+++ b/QbtManager/qbtService.cs
@@ -38,6 +38,7 @@ namespace QbtManager
             public int up_limit { get; set; }
             public float max_ratio { get; set; }
             public int max_seeding_time { get; set; }
+            public int max_inactive_seeding_time { get; set; }
             public DateTime added_on { get; set; }
             public DateTime completed_on { get; set; }
             public List<Tracker> trackers { get; set; }
@@ -219,15 +220,24 @@ namespace QbtManager
         /// <param name="taskIds"></param>
         /// <param name="maxRatio">Maximum Ratio, -2 = none, -1 = use global, other value = custom ratio per torrent</param>
         /// <param name="maxSeedingTime">Maximum Seeding Time, -2 = none, -1 = use global, other value = minutes to seed this torrent</param>
+        /// <param name="maxInactiveSeedingTime">Maximum Inactive Seeding Time, -2 = none, -1 = use global, other value = minutes to seed this torrent while inactive</param>
+        /// maxInactiveSeedingTime exists after qBittorrent 4.6.0 so it needs to be handled here
         /// <returns></returns>
-        public bool SetMaxLimits(string[] taskIds, float maxRatio, int maxSeedingTime)
+        public bool SetMaxLimits(string[] taskIds, float maxRatio, int maxSeedingTime, int maxInactiveSeedingTime)
         {
             var parms = new Dictionary<string, string>();
 
             parms["hashes"] = string.Join("|", taskIds);
             parms["ratioLimit"] = maxRatio.ToString();
             parms["seedingTimeLimit"] = maxSeedingTime.ToString();
-            Utils.Log("Setting Limits to ratio " + parms["ratioLimit"] + " seeding time " + parms["seedingTimeLimit"] + " for " + taskIds.Length.ToString() + " tasks ");
+
+            if (qbtVersion != null && (qbtVersion.CompareTo(new Version(4, 6, 0)) >= 0))
+            {
+                parms["inactiveSeedingTimeLimit"] = maxInactiveSeedingTime.ToString();
+            }
+
+            Utils.Log($"Setting Limits to ratio {parms["ratioLimit"]} seeding time {parms["seedingTimeLimit"]} minutes {(parms.TryGetValue("inactiveSeedingTimeLimit", out string inactiveSeedingTimeLimit) ? $"inactive seeding time {inactiveSeedingTimeLimit} minutes" : "")} for {taskIds.Length} tasks");
+
             return ExecuteCommand("/torrents/setShareLimits", parms);
         }
 


### PR DESCRIPTION
Hi, let me preface by saying this is the first time I touch C#.  
qBittorrent 4.6.0 merged https://github.com/qbittorrent/qBittorrent/pull/19294 adding a new required parameter to setShareLimit.  
This pull request adds support for that only on versions 4.6.0 and up, to avoid issues for people still running older qBittorrent versions.  
https://github.com/imatimba/QbtManager/blob/6beddfcd5aab5fedd6c0002d5cfbbd37ed8b912b/QbtManager/Program.cs#L200-L211 ⇽ I'm not sure if this logic is correct, but I couldn't find any errors testing different combinations of setShareLimit parameters.  

Also took the liberty to change the log string of SetMaxLimits to use string interpolation, as the concatenations + ternary operator (added because of the version check) were becoming quite unreadable.